### PR TITLE
Solution sync updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [1.1.9]
+- Updated MSAL to `@azure/msal-node` 5.1.5 and raised the VS Code engine/runtime target for Node 20 support.
+- Removed the `uuid` dependency and now use Node's built-in UUID generation.
+- Added selected-solution tracking and a status bar indicator for the solution used when publishing.
+- Publishing no longer requires opening a web resource from the extension first. The active file is matched to a server web resource by workspace-relative path.
+- If the active file is not in the selected solution, the extension prompts to add it before publishing.
+- If the active file does not exist on the server, the extension prompts to create it, add it to the selected solution, and publish it.
+- Removed `webRM.pullLatestVersionFromServer`. Opening a web resource from the extension now always pulls the server version, while still warning when an existing local file differs from a server version modified by another user.
+- Cleaned up duplicate Cancel buttons in publish confirmation dialogs.
+
 ## [1.1.8]
 - Added a new setting `webRM.pullLatestVersionFromServer` to control whether the latest version of a web resource is pulled from the CRM server when a file is opened.
 - Added a warning that appears if the file on the server was last modified by a different user and the local content is different from the server content.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ This extension contributes the following settings:
 - `webRM.dynamicsAPIVersion`: (REQUIRED) API Version for Dynamics 365 Web API
 - `webRM.solutionNameFilter`: Used to filter solution list retrieved from Dynamics
 - `webRM.solutionSortAscending`: Used to change sort order of returned solution list
-- `webRM.pullLatestVersionFromServer`: Pull latest version from CRM server when opening a web resource file.
 
 ## Known Issues
 
@@ -28,6 +27,16 @@ This extension contributes the following settings:
 Currently, this extension only works for Dynamics 365 Online. It has only been tested with version 9.0+.
 
 ## Release Notes
+
+### 1.1.9
+- Updated MSAL to `@azure/msal-node` 5.1.5 and raised the VS Code engine/runtime target for Node 20 support.
+- Removed the `uuid` dependency and now use Node's built-in UUID generation.
+- Added selected-solution tracking and a status bar indicator for the solution used when publishing.
+- Publishing no longer requires opening a web resource from the extension first. The active file is matched to a server web resource by workspace-relative path.
+- If the active file is not in the selected solution, the extension prompts to add it before publishing.
+- If the active file does not exist on the server, the extension prompts to create it, add it to the selected solution, and publish it.
+- Removed `webRM.pullLatestVersionFromServer`. Opening a web resource from the extension now always pulls the server version, while still warning when an existing local file differs from a server version modified by another user.
+- Cleaned up duplicate Cancel buttons in publish confirmation dialogs.
 
 ### 1.1.8
 - Added a new setting `webRM.pullLatestVersionFromServer` to control whether the latest version of a web resource is pulled from the CRM server when a file is opened.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Dynamics 365 Web Resource Extension for Visual Studio Code.
 
+## Important Update
+
+Version 1.1.9 includes significant workflow changes. Publishing no longer depends on opening a file from the extension first, solutions are now linked before using solution-level push/pull actions, and bulk sync actions can update multiple web resources at once. Please review the 1.1.9 release notes before upgrading.
+
 ## Features
 
 This extension allows you to connect to Dynamics 365, modify, and publish various web resources directly from VS Code.
@@ -37,6 +41,9 @@ Currently, this extension only works for Dynamics 365 Online. It has only been t
 - If the active file does not exist on the server, the extension prompts to create it, add it to the selected solution, and publish it.
 - Removed `webRM.pullLatestVersionFromServer`. Opening a web resource from the extension now always pulls the server version, while still warning when an existing local file differs from a server version modified by another user.
 - Cleaned up duplicate Cancel buttons in publish confirmation dialogs.
+- Added linked-solution actions in the Web Resources toolbar for pushing local files to the server or replacing local files with server versions.
+- Bulk push only updates web resources in the linked solution, confirms the number of changed resources, batches content updates in groups, and publishes all changed web resources in one publish request.
+- Bulk replace only updates local files for web resources in the linked solution and confirms the number of local files that will be replaced.
 
 ### 1.1.8
 - Added a new setting `webRM.pullLatestVersionFromServer` to control whether the latest version of a web resource is pulled from the CRM server when a file is opened.

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -5,7 +5,7 @@ build({
   entryPoints: ['src/extension.ts'],
   bundle: true,
   platform: 'node',
-  target: ['node18'],
+  target: ['node20'],
   outfile: 'dist/extension.js',
   external: [
     'vscode', // Only VS Code API must be external

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-webrm",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-webrm",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "dependencies": {
         "@azure/msal-node": "^5.1.5",
         "node-fetch": "^2.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,13 @@
       "name": "vscode-webrm",
       "version": "1.1.8",
       "dependencies": {
-        "@azure/msal-node": "^3.5.3",
-        "node-fetch": "^2.7.0",
-        "uuid": "^11.1.0"
+        "@azure/msal-node": "^5.1.5",
+        "node-fetch": "^2.7.0"
       },
       "devDependencies": {
         "@types/node": "22.x",
         "@types/node-fetch": "^2.6.12",
-        "@types/uuid": "^10.0.0",
-        "@types/vscode": "^1.89.0",
+        "@types/vscode": "^1.98.0",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",
         "esbuild": "^0.25.4",
@@ -24,39 +22,29 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "vscode": "^1.89.0"
+        "vscode": "^1.98.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.13.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.13.3.tgz",
-      "integrity": "sha512-shSDU7Ioecya+Aob5xliW9IGq1Ui8y4EVSdWGyI1Gbm4Vg61WpP95LuzcY214/wEjSn6w4PZYD4/iVldErHayQ==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.4.tgz",
-      "integrity": "sha512-lvuAwsDpPDE/jSuVQOBMpLbXuVuLsPNRwWCyK3/6bPlBk0fGWegqoZ0qjZclMWyQ2JNvIY3vHY7hoFmFmFQcOw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.3",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.5.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -546,9 +534,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -557,9 +545,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -620,9 +608,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -641,9 +629,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -777,13 +765,6 @@
         "form-data": "^4.0.4"
       }
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/vscode": {
       "version": "1.106.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
@@ -827,7 +808,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1032,7 +1012,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1051,9 +1030,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1105,9 +1084,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1385,7 +1364,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1471,9 +1449,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1505,9 +1483,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1678,9 +1656,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2115,13 +2093,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2247,12 +2225,11 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2426,7 +2403,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2450,19 +2426,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "XRM"
   ],
   "activationEvents": [
-    "onStartupFinished",
+    "onView:vscode-webrm-loading",
     "onCommand:wrm.addConnection",
     "onCommand:wrm.connect",
     "onCommand:wrm.removeConnection",
@@ -124,6 +124,12 @@
     },
     "views": {
       "vscode-webresourcemanager": [
+        {
+          "id": "vscode-webrm-loading",
+          "name": "Loading",
+          "icon": "$(loading)",
+          "when": "!wrm.viewsReady"
+        },
         {
           "id": "vscode-connection-explorer",
           "name": "Connection Manager",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-webrm",
   "displayName": "vscode-webrm",
   "description": "Web Resource Manager for Dataverse",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "publisher": "sheeley7",
   "icon": "resources/dark/vscode-webrm-logo.png",
   "repository": {
@@ -228,12 +228,6 @@
           "type": "boolean",
           "default": "true",
           "description": "Sort solution results in ascending order.",
-          "scope": "resource"
-        },
-        "webRM.pullLatestVersionFromServer": {
-          "type": "boolean",
-          "default": true,
-          "description": "Pull latest version from CRM server when opening a web resource file.",
           "scope": "resource"
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,20 @@
     "PowerAutomate",
     "XRM"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished",
+    "onCommand:wrm.addConnection",
+    "onCommand:wrm.connect",
+    "onCommand:wrm.removeConnection",
+    "onCommand:wrm.getWebResources",
+    "onCommand:wrm.publishWebResource",
+    "onCommand:wrm.openWebResource",
+    "onCommand:wrm.addFavoriteSolution",
+    "onCommand:wrm.removeFavoriteSolution",
+    "onCommand:wrm.filterSolutions",
+    "onCommand:wrm.toggleSolutionSortOrder",
+    "onCommand:wrm.copyConnectionUrl"
+  ],
   "main": "dist/extension.js",
   "contributes": {
     "commands": [
@@ -114,17 +127,20 @@
         {
           "id": "vscode-connection-explorer",
           "name": "Connection Manager",
-          "icon": "$(plug)"
+          "icon": "$(plug)",
+          "when": "wrm.viewsReady"
         },
         {
           "id": "vscode-solution-explorer",
           "name": "Solutions",
-          "icon": "$(package)"
+          "icon": "$(package)",
+          "when": "wrm.viewsReady"
         },
         {
           "id": "vscode-webresource-explorer",
           "name": "Web Resources",
-          "icon": "$(file-code)"
+          "icon": "$(file-code)",
+          "when": "wrm.viewsReady"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "onCommand:wrm.openWebResource",
     "onCommand:wrm.addFavoriteSolution",
     "onCommand:wrm.removeFavoriteSolution",
+    "onCommand:wrm.pushSolutionLocalFiles",
+    "onCommand:wrm.pullSolutionServerFiles",
     "onCommand:wrm.filterSolutions",
     "onCommand:wrm.toggleSolutionSortOrder",
     "onCommand:wrm.copyConnectionUrl"
@@ -93,6 +95,18 @@
         "title": "Remove Favorite",
         "category": "Web Resource Manager",
         "icon": "$(trash)"
+      },
+      {
+        "command": "wrm.pushSolutionLocalFiles",
+        "title": "Push Local Files to Server",
+        "category": "Web Resource Manager",
+        "icon": "$(cloud-upload)"
+      },
+      {
+        "command": "wrm.pullSolutionServerFiles",
+        "title": "Replace Local Files with Server",
+        "category": "Web Resource Manager",
+        "icon": "$(cloud-download)"
       },
       {
         "command": "wrm.filterSolutions",
@@ -208,6 +222,16 @@
           "command": "wrm.removeFavoriteSolution",
           "when": "view == vscode-solution-explorer && viewItem == solution",
           "icon": "$(trash)"
+        },
+        {
+          "command": "wrm.pushSolutionLocalFiles",
+          "when": "view == vscode-solution-explorer && viewItem == solution",
+          "icon": "$(cloud-upload)"
+        },
+        {
+          "command": "wrm.pullSolutionServerFiles",
+          "when": "view == vscode-solution-explorer && viewItem == solution",
+          "icon": "$(cloud-download)"
         },
         {
           "command": "wrm.openWebResource",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "onCommand:wrm.removeConnection",
     "onCommand:wrm.getWebResources",
     "onCommand:wrm.publishWebResource",
+    "onCommand:wrm.pullCurrentFileFromServer",
     "onCommand:wrm.openWebResource",
     "onCommand:wrm.addFavoriteSolution",
     "onCommand:wrm.removeFavoriteSolution",
@@ -77,6 +78,12 @@
         "title": "Dynamics: Publish Web Resource",
         "category": "Web Resource Manager",
         "icon": "$(cloud-upload)"
+      },
+      {
+        "command": "wrm.pullCurrentFileFromServer",
+        "title": "Dynamics: Pull Current File from Server",
+        "category": "Web Resource Manager",
+        "icon": "$(cloud-download)"
       },
       {
         "command": "wrm.openWebResource",
@@ -250,7 +257,21 @@
           "icon": "$(cloud-download)"
         }
       ],
-      "editor/context": []
+      "editor/context": [],
+      "editor/title": [
+        {
+          "command": "wrm.publishWebResource",
+          "when": "resourceScheme == file && wrm.viewsReady && wrm.connected && wrm.solutionLinked",
+          "group": "navigation@1",
+          "icon": "$(cloud-upload)"
+        },
+        {
+          "command": "wrm.pullCurrentFileFromServer",
+          "when": "resourceScheme == file && wrm.viewsReady && wrm.connected && wrm.solutionLinked",
+          "group": "navigation@2",
+          "icon": "$(cloud-download)"
+        }
+      ]
     },
     "configuration": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Sheeley7/vscode-webrm.git"
   },
   "engines": {
-    "vscode": "^1.89.0"
+    "vscode": "^1.98.0"
   },
   "categories": [
     "Extension Packs"
@@ -247,8 +247,7 @@
   "devDependencies": {
     "@types/node": "22.x",
     "@types/node-fetch": "^2.6.12",
-    "@types/uuid": "^10.0.0",
-    "@types/vscode": "^1.89.0",
+    "@types/vscode": "^1.98.0",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "esbuild": "^0.25.4",
@@ -256,8 +255,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@azure/msal-node": "^3.5.3",
-    "node-fetch": "^2.7.0",
-    "uuid": "^11.1.0"
+    "@azure/msal-node": "^5.1.5",
+    "node-fetch": "^2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
       },
       {
         "command": "wrm.getWebResources",
-        "title": "Get Web Resources",
+        "title": "Link Solution",
         "category": "Web Resource Manager",
-        "icon": "$(cloud-download)"
+        "icon": "$(link)"
       },
       {
         "command": "wrm.publishWebResource",
@@ -65,9 +65,9 @@
       },
       {
         "command": "wrm.openWebResource",
-        "title": "Open",
+        "title": "Pull from Server",
         "category": "Web Resource Manager",
-        "icon": "$(go-to-file)"
+        "icon": "$(cloud-download)"
       },
       {
         "command": "wrm.addFavoriteSolution",
@@ -175,7 +175,7 @@
           "command": "wrm.getWebResources",
           "when": "view == vscode-solution-explorer && viewItem == solution",
           "group": "inline",
-          "icon": "$(cloud-download)"
+          "icon": "$(cursor)"
         },
         {
           "command": "wrm.addFavoriteSolution",
@@ -191,7 +191,7 @@
           "command": "wrm.openWebResource",
           "when": "view == vscode-webresource-explorer && viewItem == webresource",
           "group": "inline",
-          "icon": "$(go-to-file)"
+          "icon": "$(cloud-download)"
         }
       ],
       "editor/context": []

--- a/package.json
+++ b/package.json
@@ -169,6 +169,14 @@
         {
           "command": "wrm.publishWebResource",
           "when": "activeEditor"
+        },
+        {
+          "command": "wrm.pushSolutionLocalFiles",
+          "when": "wrm.solutionLinked"
+        },
+        {
+          "command": "wrm.pullSolutionServerFiles",
+          "when": "wrm.solutionLinked"
         }
       ],
       "view/title": [
@@ -189,6 +197,18 @@
           "when": "view == vscode-solution-explorer",
           "group": "navigation@3",
           "icon": "$(filter)"
+        },
+        {
+          "command": "wrm.pushSolutionLocalFiles",
+          "when": "view == vscode-webresource-explorer && wrm.solutionLinked",
+          "group": "navigation@1",
+          "icon": "$(cloud-upload)"
+        },
+        {
+          "command": "wrm.pullSolutionServerFiles",
+          "when": "view == vscode-webresource-explorer && wrm.solutionLinked",
+          "group": "navigation@2",
+          "icon": "$(cloud-download)"
         }
       ],
       "view/item/context": [
@@ -222,16 +242,6 @@
           "command": "wrm.removeFavoriteSolution",
           "when": "view == vscode-solution-explorer && viewItem == solution",
           "icon": "$(trash)"
-        },
-        {
-          "command": "wrm.pushSolutionLocalFiles",
-          "when": "view == vscode-solution-explorer && viewItem == solution",
-          "icon": "$(cloud-upload)"
-        },
-        {
-          "command": "wrm.pullSolutionServerFiles",
-          "when": "view == vscode-solution-explorer && viewItem == solution",
-          "icon": "$(cloud-download)"
         },
         {
           "command": "wrm.openWebResource",

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -427,8 +427,6 @@ export function registerCommands(
                     return;
                 }
 
-                const currentUser = currentCrmConnection.getConnectionUserName();
-
                 let localContentBase64 = '';
                 let localFileExists = false;
                 try {
@@ -445,9 +443,17 @@ export function registerCommands(
 
                 const isContentDifferent = localContentBase64 !== webResourceDetails.content;
 
-                // Always show the warning if conditions are met
-                if (localFileExists && currentUser && webResourceDetails.modifiedby.fullname !== currentUser && isContentDifferent) {
-                    vscode.window.showWarningMessage(`The file on the server is different from your local version. It was last modified by ${webResourceDetails.modifiedby.fullname} on ${new Date(webResourceDetails.modifiedon).toLocaleString()}. Please verify that two developers aren't working on the same file.`, { modal: true });
+                if (localFileExists && isContentDifferent) {
+                    const overwriteChoice = await vscode.window.showWarningMessage(
+                        `The server version of '${webResource.webResourceName}' is different from your local version. It was last modified by ${webResourceDetails.modifiedby.fullname} on ${new Date(webResourceDetails.modifiedon).toLocaleString()}. Downloading it will overwrite your local file.`,
+                        { modal: true },
+                        "Overwrite Local File"
+                    );
+
+                    if (overwriteChoice !== "Overwrite Local File") {
+                        vscode.window.showInformationMessage("Download cancelled by user.");
+                        return;
+                    }
                 }
 
                 await fs.promises.writeFile(

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -128,6 +128,42 @@ function resolveSolutionArgument(solutionArg: unknown, solutionExplorer: Solutio
     return solutionExplorer.getSelectedSolution();
 }
 
+async function confirmPublishIfModifiedByOtherUser(
+    connection: Connection,
+    webResourceName: string,
+    webResourceId: string,
+    localPath: string
+): Promise<boolean> {
+    const currentUser = connection.getConnectionUserName();
+    if (!currentUser) {
+        return true;
+    }
+
+    const webResource = new WebResource(
+        webResourceName,
+        webResourceId,
+        path.basename(webResourceName),
+        localPath,
+        "",
+        "file"
+    );
+    const serverDetails = await CrmWebAPI.getWebResourceDetails(connection, webResource);
+    const lastModifiedBy = serverDetails.modifiedby?.fullname;
+
+    if (!lastModifiedBy || lastModifiedBy === currentUser) {
+        return true;
+    }
+
+    const lastModifiedOn = new Date(serverDetails.modifiedon).toLocaleString();
+    const continueChoice = await vscode.window.showWarningMessage(
+        `The server version of '${webResourceName}' was last changed by ${lastModifiedBy} on ${lastModifiedOn}. You are signed in as ${currentUser}. Publishing will overwrite the server version.`,
+        { modal: true },
+        "Continue Publish"
+    );
+
+    return continueChoice === "Continue Publish";
+}
+
 /**
  * Registers all commands for the extension.
  * Each command is wrapped in a try-catch block for robust error handling.
@@ -271,6 +307,8 @@ export function registerCommands(
                     solutionExplorer.clearSolutions();
                     webResourceExplorer.clearWebResources();
                     connectionStatusController.disconnect();
+                    await vscode.commands.executeCommand("setContext", "wrm.connected", false);
+                    await vscode.commands.executeCommand("setContext", "wrm.solutionLinked", false);
                     resetAllFileSyncState();
                 }
                 vscode.window.showInformationMessage(`Connection '${connection.label}' removed successfully.`);
@@ -312,6 +350,7 @@ export function registerCommands(
                         
                         progress.report({ increment: 20, message: "Authenticating..." });
                         await connectionStatusController.connect(); // Handles authentication
+                        await vscode.commands.executeCommand("setContext", "wrm.connected", true);
                         resetAllFileSyncState();
 
                         if (token.isCancellationRequested) return;
@@ -348,6 +387,8 @@ export function registerCommands(
                 const message = error instanceof Error ? error.message : String(error);
                 vscode.window.showErrorMessage(`Failed to connect to '${connection.label}': ${message}`);
                 connectionStatusController.disconnect(); // Ensure disconnected state on failure
+                await vscode.commands.executeCommand("setContext", "wrm.connected", false);
+                await vscode.commands.executeCommand("setContext", "wrm.solutionLinked", false);
             }
         }
     );
@@ -827,6 +868,106 @@ export function registerCommands(
     );
 
     /**
+     * Command: Pull the active file from the matching server web resource.
+     */
+    const wrmPullCurrentFileFromServer = vscode.commands.registerCommand(
+        "wrm.pullCurrentFileFromServer",
+        async () => {
+            try {
+                const activeEditor = vscode.window.activeTextEditor;
+                if (!activeEditor) {
+                    vscode.window.showInformationMessage("No active editor. Please open a web resource file to pull from the server.");
+                    return;
+                }
+
+                const document = activeEditor.document;
+                const baseName = path.basename(document.fileName);
+                const { filePath: currentPath, webResourceName } = getWebResourceNameFromDocument(document);
+
+                if (!webResourceName) {
+                    vscode.window.showErrorMessage(
+                        `'${baseName}' is not inside the current workspace. Open the file from this workspace before pulling from the server.`
+                    );
+                    return;
+                }
+
+                const connection = connectionStatusController.getCurrentConnection();
+                if (!connection) {
+                    vscode.window.showErrorMessage("No active connection. Please connect to an environment before pulling from the server.");
+                    return;
+                }
+
+                await vscode.window.withProgress(
+                    {
+                        location: vscode.ProgressLocation.Notification,
+                        title: `Pulling '${webResourceName}' from Dynamics...`,
+                        cancellable: true,
+                    },
+                    async (progress, token) => {
+                        token.onCancellationRequested(() => {
+                            vscode.window.showInformationMessage("Pull from server cancelled by user.");
+                        });
+
+                        await connection.connect();
+                        if (token.isCancellationRequested) return;
+                        progress.report({ increment: 25 });
+
+                        const serverWebResource = await CrmWebAPI.getWebResourceByName(connection, webResourceName);
+                        if (!serverWebResource) {
+                            vscode.window.showErrorMessage(`Web resource '${webResourceName}' does not exist on the server.`);
+                            return;
+                        }
+
+                        const webResource = new WebResource(
+                            serverWebResource.name,
+                            serverWebResource.webresourceid,
+                            path.basename(serverWebResource.name),
+                            currentPath,
+                            "",
+                            "file"
+                        );
+                        const serverDetails = await CrmWebAPI.getWebResourceDetails(connection, webResource);
+                        if (token.isCancellationRequested) return;
+                        progress.report({ increment: 50 });
+
+                        const localContentBase64 = await readFileBase64IfExists(currentPath);
+                        if (localContentBase64 !== undefined && localContentBase64 !== serverDetails.content) {
+                            const overwriteChoice = await vscode.window.showWarningMessage(
+                                `The server version of '${webResourceName}' is different from your local version. Pulling it will overwrite your local file.`,
+                                { modal: true },
+                                "Overwrite Local File"
+                            );
+
+                            if (overwriteChoice !== "Overwrite Local File") {
+                                vscode.window.showInformationMessage("Pull from server cancelled by user.");
+                                return;
+                            }
+                        }
+
+                        await fs.promises.mkdir(path.dirname(currentPath), { recursive: true });
+                        await fs.promises.writeFile(
+                            currentPath,
+                            serverDetails.content,
+                            { encoding: "base64" }
+                        );
+                        connectionStatusController.addSyncedWebResource(currentPath, serverWebResource.webresourceid);
+                        const fileContent = await fs.promises.readFile(currentPath, "utf8");
+                        const hash = computeFileHash(fileContent);
+                        setFileSyncState(currentPath, serverWebResource.webresourceid, true, hash);
+
+                        const doc = await vscode.workspace.openTextDocument(currentPath);
+                        await vscode.window.showTextDocument(doc);
+                        progress.report({ increment: 25 });
+                    }
+                );
+            } catch (error: unknown) {
+                const message = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Failed to pull current file from server: ${message}`);
+            }
+        }
+    );
+
+    /**
      * Command: Publish the active web resource.
      * Publishes changes from the active editor to Dynamics 365.
      */
@@ -944,6 +1085,19 @@ export function registerCommands(
                         if (!webResourceId) {
                             vscode.window.showErrorMessage(`Could not resolve Dynamics web resource '${webResourceName}'.`);
                             return;
+                        }
+
+                        if (!addedToSelectedSolution) {
+                            const shouldContinue = await confirmPublishIfModifiedByOtherUser(
+                                connection,
+                                webResourceName,
+                                webResourceId,
+                                currentPath
+                            );
+                            if (!shouldContinue) {
+                                vscode.window.showInformationMessage("Publish cancelled by user.");
+                                return;
+                            }
                         }
 
                         if (token.isCancellationRequested) return;
@@ -1099,6 +1253,7 @@ export function registerCommands(
         wrmPushSolutionLocalFiles,
         wrmPullSolutionServerFiles,
         wrmOpenWebResource,
+        wrmPullCurrentFileFromServer,
         wrmPublishWebResource,
         wrmFilterSolutions,
         wrmToggleSolutionSortOrder,

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -55,6 +55,20 @@ async function prepareWebResourceFilePath(webResourceName: string): Promise<stri
     return path.normalize(fullFilePath);
 }
 
+function getWebResourceNameFromFilePath(filePath: string): string | undefined {
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+    if (!workspaceFolder) {
+        return undefined;
+    }
+
+    const relativePath = path.relative(workspaceFolder.uri.fsPath, filePath);
+    if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+        return undefined;
+    }
+
+    return relativePath.split(path.sep).join("/");
+}
+
 /**
  * Registers all commands for the extension.
  * Each command is wrapped in a try-catch block for robust error handling.
@@ -291,6 +305,7 @@ export function registerCommands(
                 vscode.window.showErrorMessage("No solution selected or invalid solution. Please select a solution from the explorer.");
                 return;
             }
+            solutionExplorer.setSelectedSolution(solution);
             try {
                 await vscode.window.withProgress(
                     {
@@ -503,7 +518,7 @@ export function registerCommands(
                     const saveChoice = await vscode.window.showWarningMessage(
                         `'${baseName}' has unsaved changes. Save before publishing?`,
                         { modal: true },
-                        "Save and Publish", "Cancel"
+                        "Save and Publish"
                     );
                     if (saveChoice === "Save and Publish") {
                         await document.save();
@@ -540,21 +555,101 @@ export function registerCommands(
                         progress.report({ increment: 30, message: `Reading file ${baseName}...` });
 
                         const currentPath = path.normalize(fileName);
-                        // Retrieve the CRM web resource ID linked to this local file path
-                        const webResourceId = connectionStatusController.getResourceIdFromPath(currentPath);
-
-                        if (typeof webResourceId === "undefined") {
+                        const webResourceName = getWebResourceNameFromFilePath(currentPath);
+                        if (!webResourceName) {
                             vscode.window.showErrorMessage(
-                                `'${baseName}' is not linked to a Dynamics record. Please 'Open' the web resource from the explorer first to establish the link.`
+                                `'${baseName}' is not inside the current workspace. Open the file from this workspace before publishing.`
                             );
                             return;
                         }
-                        
+
+                        const selectedSolution = solutionExplorer.getSelectedSolution();
+                        if (!selectedSolution) {
+                            vscode.window.showErrorMessage(
+                                "Select a solution before publishing so the extension knows which solution to check or add the file to."
+                            );
+                            return;
+                        }
+
                         const data = await fs.promises.readFile(currentPath);
                         if (token.isCancellationRequested) return;
-
-                        progress.report({ increment: 60, message: `Publishing to CRM...` });
                         const base64 = data.toString("base64"); // Convert file content to base64
+
+                        progress.report({ increment: 45, message: `Resolving '${webResourceName}' on the server...` });
+
+                        let webResourceId = connectionStatusController.getResourceIdFromPath(currentPath);
+                        let addedToSelectedSolution = false;
+                        if (typeof webResourceId === "undefined") {
+                            const serverWebResource = await CrmWebAPI.getWebResourceByName(connection, webResourceName);
+                            webResourceId = serverWebResource?.webresourceid;
+
+                            if (!webResourceId) {
+                                const createChoice = await vscode.window.showWarningMessage(
+                                    `Web resource '${webResourceName}' does not exist on the server and is not currently in solution '${selectedSolution.getFriendlyName()}'. Create it, add it to solution '${selectedSolution.getFriendlyName()}', and publish?`,
+                                    { modal: true },
+                                    "Create, Add, and Publish"
+                                );
+
+                                if (createChoice !== "Create, Add, and Publish") {
+                                    vscode.window.showInformationMessage("Publish cancelled by user.");
+                                    return;
+                                }
+
+                                progress.report({ increment: 55, message: `Creating web resource and adding it to '${selectedSolution.getFriendlyName()}'...` });
+                                const createdWebResource = await CrmWebAPI.createWebResource(
+                                    connection,
+                                    webResourceName,
+                                    base64
+                                );
+                                webResourceId = createdWebResource.webresourceid;
+                                await CrmWebAPI.addWebResourceToSolution(
+                                    connection,
+                                    selectedSolution,
+                                    webResourceId
+                                );
+                                addedToSelectedSolution = true;
+                            }
+                        }
+
+                        if (!webResourceId) {
+                            vscode.window.showErrorMessage(`Could not resolve Dynamics web resource '${webResourceName}'.`);
+                            return;
+                        }
+
+                        if (token.isCancellationRequested) return;
+
+                        if (!addedToSelectedSolution) {
+                            progress.report({ increment: 55, message: `Checking solution '${selectedSolution.getFriendlyName()}'...` });
+                            const isInSelectedSolution = await CrmWebAPI.isWebResourceInSolution(
+                                connection,
+                                selectedSolution,
+                                webResourceId
+                            );
+
+                            if (!isInSelectedSolution) {
+                                const addChoice = await vscode.window.showWarningMessage(
+                                    `Web resource '${webResourceName}' exists on the server but is not currently in solution '${selectedSolution.getFriendlyName()}'. Add it to solution '${selectedSolution.getFriendlyName()}' and publish?`,
+                                    { modal: true },
+                                    "Add to Solution and Publish"
+                                );
+
+                                if (addChoice !== "Add to Solution and Publish") {
+                                    vscode.window.showInformationMessage("Publish cancelled by user.");
+                                    return;
+                                }
+
+                                progress.report({ increment: 65, message: `Adding to solution '${selectedSolution.getFriendlyName()}'...` });
+                                await CrmWebAPI.addWebResourceToSolution(
+                                    connection,
+                                    selectedSolution,
+                                    webResourceId
+                                );
+                            }
+                        }
+
+                        connectionStatusController.addSyncedWebResource(currentPath, webResourceId);
+
+                        progress.report({ increment: 80, message: `Publishing to CRM...` });
                         await CrmWebAPI.publishWebResource(
                             connection,
                             webResourceId,

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -112,6 +112,22 @@ async function readFileBase64IfExists(filePath: string): Promise<string | undefi
     }
 }
 
+function resolveSolutionArgument(solutionArg: unknown, solutionExplorer: SolutionExplorer): Solution | undefined {
+    if (
+        solutionArg instanceof Solution ||
+        (
+            typeof solutionArg === "object" &&
+            solutionArg !== null &&
+            "solutionId" in solutionArg &&
+            typeof (solutionArg as { solutionId?: unknown }).solutionId === "string"
+        )
+    ) {
+        return solutionArg as Solution;
+    }
+
+    return solutionExplorer.getSelectedSolution();
+}
+
 /**
  * Registers all commands for the extension.
  * Each command is wrapped in a try-catch block for robust error handling.
@@ -440,8 +456,8 @@ export function registerCommands(
 
     const wrmPushSolutionLocalFiles = vscode.commands.registerCommand(
         "wrm.pushSolutionLocalFiles",
-        async (solution?: Solution) => {
-            solution = solution ?? solutionExplorer.getSelectedSolution();
+        async (solutionArg?: unknown) => {
+            const solution = resolveSolutionArgument(solutionArg, solutionExplorer);
             if (!solution || !solution.solutionId) {
                 vscode.window.showErrorMessage("Link a solution before pushing local files.");
                 return;
@@ -587,8 +603,8 @@ export function registerCommands(
 
     const wrmPullSolutionServerFiles = vscode.commands.registerCommand(
         "wrm.pullSolutionServerFiles",
-        async (solution?: Solution) => {
-            solution = solution ?? solutionExplorer.getSelectedSolution();
+        async (solutionArg?: unknown) => {
+            const solution = resolveSolutionArgument(solutionArg, solutionExplorer);
             if (!solution || !solution.solutionId) {
                 vscode.window.showErrorMessage("Link a solution before replacing local files.");
                 return;

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -440,9 +440,10 @@ export function registerCommands(
 
     const wrmPushSolutionLocalFiles = vscode.commands.registerCommand(
         "wrm.pushSolutionLocalFiles",
-        async (solution: Solution) => {
+        async (solution?: Solution) => {
+            solution = solution ?? solutionExplorer.getSelectedSolution();
             if (!solution || !solution.solutionId) {
-                vscode.window.showErrorMessage("No solution selected to push local files.");
+                vscode.window.showErrorMessage("Link a solution before pushing local files.");
                 return;
             }
             solutionExplorer.setSelectedSolution(solution);
@@ -474,6 +475,7 @@ export function registerCommands(
                         if (token.isCancellationRequested) return;
 
                         const webResources = await CrmWebAPI.getWebResources(connection, solution);
+                        const serverDetailsById = await CrmWebAPI.getWebResourceDetailsBatch(connection, webResources, 10);
                         const total = webResources.length || 1;
 
                         for (let i = 0; i < webResources.length; i++) {
@@ -491,7 +493,10 @@ export function registerCommands(
                                 continue;
                             }
 
-                            const serverDetails = await CrmWebAPI.getWebResourceDetails(connection, webResource);
+                            const serverDetails = serverDetailsById.get(webResource.webResourceId);
+                            if (!serverDetails) {
+                                throw new Error(`Could not retrieve server details for '${webResource.webResourceName}'.`);
+                            }
                             if (localContentBase64 !== serverDetails.content) {
                                 candidates.push({
                                     webResource,
@@ -582,9 +587,10 @@ export function registerCommands(
 
     const wrmPullSolutionServerFiles = vscode.commands.registerCommand(
         "wrm.pullSolutionServerFiles",
-        async (solution: Solution) => {
+        async (solution?: Solution) => {
+            solution = solution ?? solutionExplorer.getSelectedSolution();
             if (!solution || !solution.solutionId) {
-                vscode.window.showErrorMessage("No solution selected to replace local files.");
+                vscode.window.showErrorMessage("Link a solution before replacing local files.");
                 return;
             }
             solutionExplorer.setSelectedSolution(solution);
@@ -616,6 +622,7 @@ export function registerCommands(
                         if (token.isCancellationRequested) return;
 
                         const webResources = await CrmWebAPI.getWebResources(connection, solution);
+                        const serverDetailsById = await CrmWebAPI.getWebResourceDetailsBatch(connection, webResources, 10);
                         const total = webResources.length || 1;
 
                         for (let i = 0; i < webResources.length; i++) {
@@ -627,7 +634,10 @@ export function registerCommands(
                                 throw new Error(`Could not prepare local path for '${webResource.webResourceName}'.`);
                             }
 
-                            const serverDetails = await CrmWebAPI.getWebResourceDetails(connection, webResource);
+                            const serverDetails = serverDetailsById.get(webResource.webResourceId);
+                            if (!serverDetails) {
+                                throw new Error(`Could not retrieve server details for '${webResource.webResourceName}'.`);
+                            }
                             const localContentBase64 = await readFileBase64IfExists(localPath);
                             if (localContentBase64 !== serverDetails.content) {
                                 candidates.push({

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -55,6 +55,15 @@ async function prepareWebResourceFilePath(webResourceName: string): Promise<stri
     return path.normalize(fullFilePath);
 }
 
+function getLocalFilePathForWebResourceName(webResourceName: string): string | undefined {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return undefined;
+    }
+
+    return path.normalize(path.join(workspaceFolders[0].uri.fsPath, ...webResourceName.split("/")));
+}
+
 function getWebResourceNameFromDocument(document: vscode.TextDocument): { filePath: string; webResourceName?: string } {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     let rawFilePath = document.uri.fsPath || document.fileName;
@@ -89,6 +98,18 @@ function getWebResourceNameFromDocument(document: vscode.TextDocument): { filePa
         filePath,
         webResourceName: relativePath.split(path.sep).join("/"),
     };
+}
+
+async function readFileBase64IfExists(filePath: string): Promise<string | undefined> {
+    try {
+        const content = await fs.promises.readFile(filePath);
+        return content.toString("base64");
+    } catch (error: any) {
+        if (error.code === "ENOENT") {
+            return undefined;
+        }
+        throw error;
+    }
 }
 
 /**
@@ -413,6 +434,271 @@ export function registerCommands(
                 vscode.window.showErrorMessage(
                     `Error removing solution '${solution.getFriendlyName()}' from favorites: ${message}`
                 );
+            }
+        }
+    );
+
+    const wrmPushSolutionLocalFiles = vscode.commands.registerCommand(
+        "wrm.pushSolutionLocalFiles",
+        async (solution: Solution) => {
+            if (!solution || !solution.solutionId) {
+                vscode.window.showErrorMessage("No solution selected to push local files.");
+                return;
+            }
+            solutionExplorer.setSelectedSolution(solution);
+
+            const connection = connectionStatusController.getCurrentConnection();
+            if (!connection) {
+                vscode.window.showErrorMessage("No active connection. Please connect to an environment before pushing local files.");
+                return;
+            }
+
+            const solutionName = solution.getFriendlyName();
+            const candidates: Array<{ webResource: WebResource; localPath: string; base64Content: string }> = [];
+            let wasCancelled = false;
+
+            try {
+                await vscode.window.withProgress(
+                    {
+                        location: vscode.ProgressLocation.Notification,
+                        title: `Checking local files for '${solutionName}'...`,
+                        cancellable: true,
+                    },
+                    async (progress, token) => {
+                        token.onCancellationRequested(() => {
+                            wasCancelled = true;
+                            vscode.window.showInformationMessage("Push local files cancelled by user.");
+                        });
+
+                        await connection.connect();
+                        if (token.isCancellationRequested) return;
+
+                        const webResources = await CrmWebAPI.getWebResources(connection, solution);
+                        const total = webResources.length || 1;
+
+                        for (let i = 0; i < webResources.length; i++) {
+                            if (token.isCancellationRequested) return;
+
+                            const webResource = webResources[i];
+                            const localPath = getLocalFilePathForWebResourceName(webResource.webResourceName);
+                            if (!localPath) {
+                                throw new Error("No workspace folder is open. Please open a folder before pushing local files.");
+                            }
+
+                            const localContentBase64 = await readFileBase64IfExists(localPath);
+                            if (localContentBase64 === undefined) {
+                                progress.report({ increment: 50 / total });
+                                continue;
+                            }
+
+                            const serverDetails = await CrmWebAPI.getWebResourceDetails(connection, webResource);
+                            if (localContentBase64 !== serverDetails.content) {
+                                candidates.push({
+                                    webResource,
+                                    localPath,
+                                    base64Content: localContentBase64,
+                                });
+                            }
+
+                            progress.report({ increment: 50 / total });
+                        }
+                    }
+                );
+
+                if (wasCancelled) {
+                    return;
+                }
+
+                if (candidates.length === 0) {
+                    vscode.window.showInformationMessage(`No local files need to be pushed for solution '${solutionName}'.`);
+                    return;
+                }
+
+                const pushLabel = `Push ${candidates.length} Web Resource${candidates.length === 1 ? "" : "s"}`;
+                const confirm = await vscode.window.showWarningMessage(
+                    `${candidates.length} web resource${candidates.length === 1 ? "" : "s"} in solution '${solutionName}' will be updated on the server from local files. Continue?`,
+                    { modal: true },
+                    pushLabel
+                );
+                if (confirm !== pushLabel) {
+                    vscode.window.showInformationMessage("Push local files cancelled by user.");
+                    return;
+                }
+
+                await vscode.window.withProgress(
+                    {
+                        location: vscode.ProgressLocation.Notification,
+                        title: `Pushing ${candidates.length} web resource${candidates.length === 1 ? "" : "s"} to '${solutionName}'...`,
+                        cancellable: true,
+                    },
+                    async (progress, token) => {
+                        token.onCancellationRequested(() => {
+                            wasCancelled = true;
+                        });
+
+                        if (token.isCancellationRequested) {
+                            vscode.window.showInformationMessage("Push local files cancelled by user.");
+                            return;
+                        }
+
+                        await CrmWebAPI.updateWebResourcesBatch(
+                            connection,
+                            candidates.map(candidate => ({
+                                webResourceId: candidate.webResource.webResourceId,
+                                base64Content: candidate.base64Content,
+                            }))
+                        );
+                        progress.report({ increment: 75 });
+
+                        if (token.isCancellationRequested) {
+                            vscode.window.showInformationMessage("Push local files cancelled by user.");
+                            return;
+                        }
+
+                        await CrmWebAPI.publishWebResources(
+                            connection,
+                            candidates.map(candidate => candidate.webResource.webResourceId)
+                        );
+                        progress.report({ increment: 25 });
+
+                        for (const candidate of candidates) {
+                            connectionStatusController.addSyncedWebResource(candidate.localPath, candidate.webResource.webResourceId);
+                            setFileSyncState(candidate.localPath, candidate.webResource.webResourceId, true);
+                        }
+                    }
+                );
+
+                if (wasCancelled) {
+                    return;
+                }
+
+                vscode.window.showInformationMessage(`Pushed ${candidates.length} web resource${candidates.length === 1 ? "" : "s"} to Dynamics for solution '${solutionName}'.`);
+            } catch (error: unknown) {
+                const message = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Failed to push local files for solution '${solutionName}': ${message}`);
+            }
+        }
+    );
+
+    const wrmPullSolutionServerFiles = vscode.commands.registerCommand(
+        "wrm.pullSolutionServerFiles",
+        async (solution: Solution) => {
+            if (!solution || !solution.solutionId) {
+                vscode.window.showErrorMessage("No solution selected to replace local files.");
+                return;
+            }
+            solutionExplorer.setSelectedSolution(solution);
+
+            const connection = connectionStatusController.getCurrentConnection();
+            if (!connection) {
+                vscode.window.showErrorMessage("No active connection. Please connect to an environment before replacing local files.");
+                return;
+            }
+
+            const solutionName = solution.getFriendlyName();
+            const candidates: Array<{ webResource: WebResource; localPath: string; serverContent: string }> = [];
+            let wasCancelled = false;
+
+            try {
+                await vscode.window.withProgress(
+                    {
+                        location: vscode.ProgressLocation.Notification,
+                        title: `Checking server files for '${solutionName}'...`,
+                        cancellable: true,
+                    },
+                    async (progress, token) => {
+                        token.onCancellationRequested(() => {
+                            wasCancelled = true;
+                            vscode.window.showInformationMessage("Replace local files cancelled by user.");
+                        });
+
+                        await connection.connect();
+                        if (token.isCancellationRequested) return;
+
+                        const webResources = await CrmWebAPI.getWebResources(connection, solution);
+                        const total = webResources.length || 1;
+
+                        for (let i = 0; i < webResources.length; i++) {
+                            if (token.isCancellationRequested) return;
+
+                            const webResource = webResources[i];
+                            const localPath = await prepareWebResourceFilePath(webResource.webResourceName);
+                            if (!localPath) {
+                                throw new Error(`Could not prepare local path for '${webResource.webResourceName}'.`);
+                            }
+
+                            const serverDetails = await CrmWebAPI.getWebResourceDetails(connection, webResource);
+                            const localContentBase64 = await readFileBase64IfExists(localPath);
+                            if (localContentBase64 !== serverDetails.content) {
+                                candidates.push({
+                                    webResource,
+                                    localPath,
+                                    serverContent: serverDetails.content,
+                                });
+                            }
+
+                            progress.report({ increment: 50 / total });
+                        }
+                    }
+                );
+
+                if (wasCancelled) {
+                    return;
+                }
+
+                if (candidates.length === 0) {
+                    vscode.window.showInformationMessage(`No local files need to be replaced for solution '${solutionName}'.`);
+                    return;
+                }
+
+                const replaceLabel = `Replace ${candidates.length} Local File${candidates.length === 1 ? "" : "s"}`;
+                const confirm = await vscode.window.showWarningMessage(
+                    `${candidates.length} local file${candidates.length === 1 ? "" : "s"} for solution '${solutionName}' will be replaced with the server version. Continue?`,
+                    { modal: true },
+                    replaceLabel
+                );
+                if (confirm !== replaceLabel) {
+                    vscode.window.showInformationMessage("Replace local files cancelled by user.");
+                    return;
+                }
+
+                await vscode.window.withProgress(
+                    {
+                        location: vscode.ProgressLocation.Notification,
+                        title: `Replacing ${candidates.length} local file${candidates.length === 1 ? "" : "s"} for '${solutionName}'...`,
+                        cancellable: true,
+                    },
+                    async (progress, token) => {
+                        token.onCancellationRequested(() => {
+                            wasCancelled = true;
+                        });
+                        const total = candidates.length || 1;
+                        for (const candidate of candidates) {
+                            if (token.isCancellationRequested) {
+                                vscode.window.showInformationMessage("Replace local files cancelled by user.");
+                                return;
+                            }
+
+                            await fs.promises.writeFile(
+                                candidate.localPath,
+                                candidate.serverContent,
+                                { encoding: "base64" }
+                            );
+                            connectionStatusController.addSyncedWebResource(candidate.localPath, candidate.webResource.webResourceId);
+                            setFileSyncState(candidate.localPath, candidate.webResource.webResourceId, true);
+                            progress.report({ increment: 100 / total });
+                        }
+                    }
+                );
+
+                if (wasCancelled) {
+                    return;
+                }
+
+                vscode.window.showInformationMessage(`Replaced ${candidates.length} local file${candidates.length === 1 ? "" : "s"} from Dynamics for solution '${solutionName}'.`);
+            } catch (error: unknown) {
+                const message = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Failed to replace local files for solution '${solutionName}': ${message}`);
             }
         }
     );
@@ -784,6 +1070,8 @@ export function registerCommands(
         wrmGetWebResources,
         wrmAddFavoriteSolution,
         wrmRemoveFavoriteSolution,
+        wrmPushSolutionLocalFiles,
+        wrmPullSolutionServerFiles,
         wrmOpenWebResource,
         wrmPublishWebResource,
         wrmFilterSolutions,

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -430,9 +430,11 @@ export function registerCommands(
                 const currentUser = currentCrmConnection.getConnectionUserName();
 
                 let localContentBase64 = '';
+                let localFileExists = false;
                 try {
                     const localContent = await fs.promises.readFile(fullFilePath);
                     localContentBase64 = localContent.toString('base64');
+                    localFileExists = true;
                 } catch (error: any) {
                     if (error.code !== 'ENOENT') {
                         // ENOENT is fine, means the file doesn't exist locally yet.
@@ -444,27 +446,15 @@ export function registerCommands(
                 const isContentDifferent = localContentBase64 !== webResourceDetails.content;
 
                 // Always show the warning if conditions are met
-                if (currentUser && webResourceDetails.modifiedby.fullname !== currentUser && isContentDifferent) {
+                if (localFileExists && currentUser && webResourceDetails.modifiedby.fullname !== currentUser && isContentDifferent) {
                     vscode.window.showWarningMessage(`The file on the server is different from your local version. It was last modified by ${webResourceDetails.modifiedby.fullname} on ${new Date(webResourceDetails.modifiedon).toLocaleString()}. Please verify that two developers aren't working on the same file.`, { modal: true });
                 }
 
-                const pullLatest = ConfigurationService.getPullLatestVersionFromServer();
-                if (pullLatest) {
-                    // Only write content to the local file if the setting is enabled
-                    await fs.promises.writeFile(
-                        fullFilePath,
-                        webResourceDetails.content,
-                        { encoding: "base64" } // Assuming content is base64 encoded
-                    );
-                } else {
-                    // If not pulling latest, check if the file exists locally
-                    try {
-                        await fs.promises.access(fullFilePath);
-                    } catch (error) {
-                        vscode.window.showErrorMessage(`Local file not found for '${webResource.webResourceName}'. Enable "Pull Latest Version from CRM Server" to download it.`, { modal: true });
-                        return; // Stop execution
-                    }
-                }
+                await fs.promises.writeFile(
+                    fullFilePath,
+                    webResourceDetails.content,
+                    { encoding: "base64" } // Assuming content is base64 encoded
+                );
                 
                 // Open the local file in VS Code editor
                 const doc = await vscode.workspace.openTextDocument(fullFilePath);
@@ -484,7 +474,7 @@ export function registerCommands(
                         // Read file content as text (after writing base64 decoded content)
                         const fileContent = await fs.promises.readFile(fullFilePath, 'utf8');
                         const hash = ext.computeFileHash(fileContent);
-                        ext.setFileSyncState(fullFilePath, webResource.webResourceId, pullLatest, hash);
+                        ext.setFileSyncState(fullFilePath, webResource.webResourceId, true, hash);
                     }
                 } catch (e) {
                     // fallback: do nothing if import fails

--- a/src/commandHandlers.ts
+++ b/src/commandHandlers.ts
@@ -55,18 +55,40 @@ async function prepareWebResourceFilePath(webResourceName: string): Promise<stri
     return path.normalize(fullFilePath);
 }
 
-function getWebResourceNameFromFilePath(filePath: string): string | undefined {
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+function getWebResourceNameFromDocument(document: vscode.TextDocument): { filePath: string; webResourceName?: string } {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    let rawFilePath = document.uri.fsPath || document.fileName;
+    if (workspaceFolders?.length === 1 && rawFilePath && !path.isAbsolute(rawFilePath)) {
+        rawFilePath = path.join(workspaceFolders[0].uri.fsPath, rawFilePath);
+    }
+    const filePath = path.normalize(rawFilePath);
+
+    if (!workspaceFolders || workspaceFolders.length === 0 || document.uri.scheme !== "file") {
+        return { filePath };
+    }
+
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)
+        ?? workspaceFolders
+            .map(folder => ({
+                folder,
+                relativePath: path.relative(folder.uri.fsPath, filePath),
+            }))
+            .filter(candidate => candidate.relativePath && !candidate.relativePath.startsWith("..") && !path.isAbsolute(candidate.relativePath))
+            .sort((a, b) => a.relativePath.length - b.relativePath.length)[0]?.folder;
+
     if (!workspaceFolder) {
-        return undefined;
+        return { filePath };
     }
 
     const relativePath = path.relative(workspaceFolder.uri.fsPath, filePath);
     if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
-        return undefined;
+        return { filePath };
     }
 
-    return relativePath.split(path.sep).join("/");
+    return {
+        filePath,
+        webResourceName: relativePath.split(path.sep).join("/"),
+    };
 }
 
 /**
@@ -508,11 +530,13 @@ export function registerCommands(
                 const document = activeEditor.document;
                 const fileName = document.fileName; // Full local path of the active file
                 const baseName = path.basename(fileName); // File name part for messages
+                const { filePath: currentPath, webResourceName } = getWebResourceNameFromDocument(document);
+                const progressName = webResourceName ?? baseName;
 
                 // Prompt to save if dirty
                 if (document.isDirty) {
                     const saveChoice = await vscode.window.showWarningMessage(
-                        `'${baseName}' has unsaved changes. Save before publishing?`,
+                        `'${progressName}' has unsaved changes. Save before publishing?`,
                         { modal: true },
                         "Save and Publish"
                     );
@@ -527,7 +551,7 @@ export function registerCommands(
                 await vscode.window.withProgress(
                     {
                         location: vscode.ProgressLocation.Notification,
-                        title: `Publishing '${baseName}'...`,
+                        title: `Publishing '${progressName}' to Dynamics...`,
                         cancellable: true,
                     },
                     async (progress, token) => {
@@ -544,14 +568,12 @@ export function registerCommands(
                             return;
                         }
                         
-                        progress.report({ increment: 10, message: "Verifying connection..." });
+                        progress.report({ increment: 10 });
                         await connection.connect(); // Ensure connection is active and token is valid
 
                         if (token.isCancellationRequested) return;
-                        progress.report({ increment: 30, message: `Reading file ${baseName}...` });
+                        progress.report({ increment: 30 });
 
-                        const currentPath = path.normalize(fileName);
-                        const webResourceName = getWebResourceNameFromFilePath(currentPath);
                         if (!webResourceName) {
                             vscode.window.showErrorMessage(
                                 `'${baseName}' is not inside the current workspace. Open the file from this workspace before publishing.`
@@ -571,7 +593,7 @@ export function registerCommands(
                         if (token.isCancellationRequested) return;
                         const base64 = data.toString("base64"); // Convert file content to base64
 
-                        progress.report({ increment: 45, message: `Resolving '${webResourceName}' on the server...` });
+                        progress.report({ increment: 45 });
 
                         let webResourceId = connectionStatusController.getResourceIdFromPath(currentPath);
                         let addedToSelectedSolution = false;
@@ -591,7 +613,7 @@ export function registerCommands(
                                     return;
                                 }
 
-                                progress.report({ increment: 55, message: `Creating web resource and adding it to '${selectedSolution.getFriendlyName()}'...` });
+                                progress.report({ increment: 55 });
                                 const createdWebResource = await CrmWebAPI.createWebResource(
                                     connection,
                                     webResourceName,
@@ -615,7 +637,7 @@ export function registerCommands(
                         if (token.isCancellationRequested) return;
 
                         if (!addedToSelectedSolution) {
-                            progress.report({ increment: 55, message: `Checking solution '${selectedSolution.getFriendlyName()}'...` });
+                            progress.report({ increment: 55 });
                             const isInSelectedSolution = await CrmWebAPI.isWebResourceInSolution(
                                 connection,
                                 selectedSolution,
@@ -634,7 +656,7 @@ export function registerCommands(
                                     return;
                                 }
 
-                                progress.report({ increment: 65, message: `Adding to solution '${selectedSolution.getFriendlyName()}'...` });
+                                progress.report({ increment: 65 });
                                 await CrmWebAPI.addWebResourceToSolution(
                                     connection,
                                     selectedSolution,
@@ -645,13 +667,13 @@ export function registerCommands(
 
                         connectionStatusController.addSyncedWebResource(currentPath, webResourceId);
 
-                        progress.report({ increment: 80, message: `Publishing to CRM...` });
+                        progress.report({ increment: 80 });
                         await CrmWebAPI.publishWebResource(
                             connection,
                             webResourceId,
                             base64
                         );
-                        progress.report({ increment: 100, message: `Successfully published '${baseName}'.`});
+                        progress.report({ increment: 100 });
 
                         // Update the status bar to 'Published' and update hash
                         const fileContent = await fs.promises.readFile(fileName, 'utf8');

--- a/src/configurationService.ts
+++ b/src/configurationService.ts
@@ -65,16 +65,6 @@ export class ConfigurationService {
     }
 
     /**
-     * Gets the 'pullLatestVersionFromServer' boolean flag from the extension settings.
-     * Determines if the latest version of a web resource should be pulled from the CRM server.
-     * Defaults to true if not set.
-     * @returns {boolean} True if the latest version should be pulled, false otherwise.
-     */
-    static getPullLatestVersionFromServer(): boolean {
-        return this.getConfiguration().get("pullLatestVersionFromServer", true);
-    }
-
-    /**
      * Gets the 'appTenantId' (Application Tenant ID) from the extension settings.
      * This ID specifies the Azure AD tenant to authenticate against.
      * @returns {string | undefined} The Application Tenant ID, or undefined if not set.

--- a/src/crmWebAPI.ts
+++ b/src/crmWebAPI.ts
@@ -65,6 +65,11 @@ interface UpdateRequest {
     [key: string]: string | number | boolean | undefined; // Allows other string-keyed properties.
 }
 
+interface WebResourceContentUpdate {
+    webResourceId: string;
+    base64Content: string;
+}
+
 /**
  * Defines the structure for parameters passed to the PublishXml Dynamics 365 action.
  */
@@ -97,6 +102,10 @@ const QUERY_ORDERBY = "&$orderby=";
  * This class encapsulates data retrieval and modification operations.
  */
 export class CrmWebAPI {
+    private static createBoundary(prefix: string): string {
+        return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+    }
+
     private static escapeODataString(value: string): string {
         return value.replace(/'/g, "''");
     }
@@ -369,13 +378,84 @@ export class CrmWebAPI {
             // Step 2: Publish the web resource using PublishXml action.
             await this.publishXML(
                 connection,
-                webResourceId
+                [webResourceId]
             );
         } catch (err: unknown) { // Catching unknown for type safety.
             // Add more context to the error if it's an Error object.
             const message = err instanceof Error ? err.message : String(err);
             throw new Error(`Error publishing web resource (ID: ${webResourceId}): ${message}`);
         }
+    }
+
+    /**
+     * Updates multiple web resource records in a single non-transactional OData batch request.
+     */
+    static async updateWebResourcesBatch(
+        connection: Connection,
+        updates: WebResourceContentUpdate[]
+    ): Promise<void> {
+        if (updates.length === 0) {
+            return;
+        }
+
+        const apiVersion = ConfigurationService.getDynamicsAPIVersion();
+        const batchBoundary = this.createBoundary("batch");
+        const crlf = "\r\n";
+        const requestParts: string[] = [];
+
+        for (const update of updates) {
+            requestParts.push(
+                `--${batchBoundary}`,
+                "Content-Type: application/http",
+                "Content-Transfer-Encoding: binary",
+                "",
+                `PATCH ${API_DATA_V}${apiVersion}/${ENTITY_WEBRESOURCE_SET}(${update.webResourceId}) HTTP/1.1`,
+                "Content-Type: application/json; type=entry",
+                "",
+                JSON.stringify({ content: update.base64Content })
+            );
+        }
+
+        const batchBody = [
+            ...requestParts,
+            `--${batchBoundary}--`,
+            "",
+        ].join(crlf);
+
+        await this.makeRawApiRequest(
+            connection,
+            "POST",
+            `${API_DATA_V}${apiVersion}/$batch`,
+            batchBody,
+            `multipart/mixed; boundary="${batchBoundary}"`,
+            responseText => {
+                const innerStatusMatches = [...responseText.matchAll(/HTTP\/1\.1\s+(\d{3})/g)];
+                if (innerStatusMatches.length !== updates.length) {
+                    throw new Error(`Batch update returned ${innerStatusMatches.length} responses for ${updates.length} updates: ${responseText}`);
+                }
+
+                const failedStatus = innerStatusMatches
+                    .map(match => Number(match[1]))
+                    .find(status => status < 200 || status >= 300);
+
+                if (failedStatus) {
+                    throw new Error(`Batch update returned inner HTTP status ${failedStatus}: ${responseText}`);
+                }
+            }
+        );
+    }
+
+    /**
+     * Publishes multiple web resources using one PublishXml request.
+     */
+    static async publishWebResources(
+        connection: Connection,
+        webResourceIds: string[]
+    ): Promise<void> {
+        if (webResourceIds.length === 0) {
+            return;
+        }
+        await this.publishXML(connection, webResourceIds);
     }
 
     /**
@@ -472,6 +552,44 @@ export class CrmWebAPI {
         })(); // Immediately invoke the async IIFE
     }
 
+    private static async makeRawApiRequest(
+        connection: Connection,
+        method: string,
+        apiQuery: string,
+        body: string,
+        contentType: string,
+        validateResponseText?: (responseText: string) => void
+    ): Promise<string> {
+        await connection.connect();
+
+        const accessToken = connection.getAccessToken();
+        if (!accessToken) {
+            throw new Error("No access token available for API request. Please connect first.");
+        }
+
+        const headers: { [key: string]: string } = {
+            "OData-MaxVersion": ODATA_MAX_VERSION,
+            "OData-Version": ODATA_VERSION,
+            "Accept": "application/json",
+            "Content-Type": contentType,
+            "Authorization": "Bearer " + accessToken,
+        };
+
+        const res: Response = await fetch(connection.getConnectionURL() + apiQuery, {
+            method,
+            headers,
+            body,
+        });
+        const responseText = await res.text();
+
+        if (!res.ok) {
+            throw new Error(`API request to '${apiQuery}' completed with status ${res.status}: ${responseText || res.statusText}`);
+        }
+
+        validateResponseText?.(responseText);
+        return responseText;
+    }
+
     /**
      * Retrieves multiple records from a Dynamics 365 entity set.
      * Expects the response to be an OData collection with a 'value' property containing an array of records.
@@ -550,20 +668,23 @@ export class CrmWebAPI {
      * Publishes XML changes to Dynamics 365. Used for publishing web resources.
      *
      * @param {Connection} connection The active Dynamics 365 connection object.
-     * @param {string} webResourceId The GUID of the web resource to include in the publish XML.
+     * @param {string[]} webResourceIds The GUIDs of the web resources to include in the publish XML.
      * @returns {Promise<void>} A promise that resolves when the PublishXml action is successful.
      * @throws {Error} If the PublishXml request fails.
      * @private
      */
     private static async publishXML(
         connection: Connection,
-        webResourceId: string
+        webResourceIds: string[]
     ): Promise<void> { 
         const apiVersion = ConfigurationService.getDynamicsAPIVersion();
+        const webResourceXml = webResourceIds
+            .map(webResourceId => `<webresource>{${webResourceId}}</webresource>`)
+            .join("");
         // Construct the ParameterXml required by the PublishXml action.
         const parameters: PublishXmlParams = { 
             ParameterXml:
-                `<importexportxml><webresources><webresource>{${webResourceId}}</webresource></webresources></importexportxml>`,
+                `<importexportxml><webresources>${webResourceXml}</webresources></importexportxml>`,
         };
         const publishQuery = `${API_DATA_V}${apiVersion}/PublishXml`; // The OData action path.
         // PublishXml action might return a specific response or just a success status.

--- a/src/crmWebAPI.ts
+++ b/src/crmWebAPI.ts
@@ -28,6 +28,12 @@ interface RawWebResource {
     // Additional properties can be added.
 }
 
+interface ServerWebResource {
+    webresourceid: string;
+    name: string;
+    webresourcetype?: number;
+}
+
 /**
  * Represents the structure of the response when fetching the content of a single web resource.
  */
@@ -91,6 +97,36 @@ const QUERY_ORDERBY = "&$orderby=";
  * This class encapsulates data retrieval and modification operations.
  */
 export class CrmWebAPI {
+    private static escapeODataString(value: string): string {
+        return value.replace(/'/g, "''");
+    }
+
+    private static getWebResourceTypeFromName(webResourceName: string): number {
+        const extension = path.extname(webResourceName).toLowerCase();
+        const typeByExtension: Record<string, number> = {
+            ".html": 1,
+            ".htm": 1,
+            ".css": 2,
+            ".js": 3,
+            ".xml": 4,
+            ".png": 5,
+            ".jpg": 6,
+            ".jpeg": 6,
+            ".gif": 7,
+            ".xap": 8,
+            ".xsl": 9,
+            ".xslt": 9,
+            ".ico": 10,
+            ".svg": 11,
+            ".resx": 12,
+        };
+        const webResourceType = typeByExtension[extension];
+        if (!webResourceType) {
+            throw new Error(`Unsupported web resource file type '${extension || "(none)"}' for '${webResourceName}'.`);
+        }
+        return webResourceType;
+    }
+
     /**
      * Retrieves a list of solutions from the connected Dynamics 365 environment.
      * Filters solutions based on configuration settings (name filter, visibility, managed status).
@@ -218,6 +254,91 @@ export class CrmWebAPI {
             // Handle non-Error objects thrown, though this is rare in well-behaved async code.
             throw new Error(`An unknown error occurred while processing web resources: ${String(err)}`);
         }
+    }
+
+    /**
+     * Finds a web resource by its logical name anywhere on the server.
+     */
+    static async getWebResourceByName(connection: Connection, webResourceName: string): Promise<ServerWebResource | null> {
+        const apiVersion = ConfigurationService.getDynamicsAPIVersion();
+        const escapedName = this.escapeODataString(webResourceName);
+        const query =
+            `${API_DATA_V}${apiVersion}/${ENTITY_WEBRESOURCE_SET}` +
+            `${QUERY_SELECT}webresourceid,name,webresourcetype` +
+            `${QUERY_FILTER}name eq '${escapedName}'&$top=1`;
+
+        const results = await this.getRecords<ServerWebResource>(connection, query);
+        return results[0] ?? null;
+    }
+
+    /**
+     * Checks whether a web resource is already part of a solution.
+     */
+    static async isWebResourceInSolution(
+        connection: Connection,
+        solution: Solution,
+        webResourceId: string
+    ): Promise<boolean> {
+        const apiVersion = ConfigurationService.getDynamicsAPIVersion();
+        const query =
+            `${API_DATA_V}${apiVersion}/${ENTITY_MSDYN_SOLUTION_COMPONENT_SUMMARIES}` +
+            `${QUERY_SELECT}msdyn_objectid` +
+            `${QUERY_FILTER}(msdyn_solutionid eq ${solution.solutionId}) and ` +
+            `(msdyn_componenttype eq 61) and (msdyn_objectid eq ${webResourceId})&$top=1`;
+
+        const results = await this.getRecords<RawWebResource>(connection, query);
+        return results.length > 0;
+    }
+
+    /**
+     * Creates a new web resource record using the provided base64 content.
+     */
+    static async createWebResource(
+        connection: Connection,
+        webResourceName: string,
+        base64Content: string
+    ): Promise<ServerWebResource> {
+        const fileName = path.basename(webResourceName);
+        const webResourceType = this.getWebResourceTypeFromName(webResourceName);
+        await this.createRecord(
+            connection,
+            {
+                name: webResourceName,
+                displayname: fileName,
+                webresourcetype: webResourceType,
+                content: base64Content,
+            },
+            ENTITY_WEBRESOURCE_SET
+        );
+
+        const createdWebResource = await this.getWebResourceByName(connection, webResourceName);
+        if (!createdWebResource) {
+            throw new Error(`Created web resource '${webResourceName}', but could not retrieve it from the server.`);
+        }
+        return createdWebResource;
+    }
+
+    /**
+     * Adds an existing web resource to a solution.
+     */
+    static async addWebResourceToSolution(
+        connection: Connection,
+        solution: Solution,
+        webResourceId: string
+    ): Promise<void> {
+        const apiVersion = ConfigurationService.getDynamicsAPIVersion();
+        const addSolutionComponentQuery = `${API_DATA_V}${apiVersion}/AddSolutionComponent`;
+        await this.makeApiRequest<unknown, Record<string, string | number | boolean>>(
+            connection,
+            "POST",
+            addSolutionComponentQuery,
+            {
+                ComponentId: webResourceId,
+                ComponentType: 61,
+                SolutionUniqueName: solution.solutionUniqueName,
+                AddRequiredComponents: false,
+            }
+        );
     }
 
     /**
@@ -410,6 +531,19 @@ export class CrmWebAPI {
         // PATCH requests typically return 204 No Content, so TResponsePayload is void.
         await this.makeApiRequest<void, UpdateRequest>(connection, "PATCH", updateQuery, record);
         // Success is implied if no error is thrown.
+    }
+
+    /**
+     * Creates a record in Dynamics 365 using a POST request.
+     */
+    private static async createRecord(
+        connection: Connection,
+        record: UpdateRequest,
+        entityName: string
+    ): Promise<void> {
+        const apiVersion = ConfigurationService.getDynamicsAPIVersion();
+        const createQuery = `${API_DATA_V}${apiVersion}/${entityName}`;
+        await this.makeApiRequest<void, UpdateRequest>(connection, "POST", createQuery, record);
     }
 
     /**

--- a/src/crmWebAPI.ts
+++ b/src/crmWebAPI.ts
@@ -65,6 +65,10 @@ interface UpdateRequest {
     [key: string]: string | number | boolean | undefined; // Allows other string-keyed properties.
 }
 
+interface WebResourceBatchDetail extends WebResourceContent {
+    webResourceId: string;
+}
+
 interface WebResourceContentUpdate {
     webResourceId: string;
     base64Content: string;
@@ -446,6 +450,69 @@ export class CrmWebAPI {
     }
 
     /**
+     * Retrieves web resource details in non-transactional OData batch GET requests.
+     */
+    static async getWebResourceDetailsBatch(
+        connection: Connection,
+        webResources: WebResource[],
+        batchSize: number = 10
+    ): Promise<Map<string, WebResourceBatchDetail>> {
+        const details = new Map<string, WebResourceBatchDetail>();
+        if (webResources.length === 0) {
+            return details;
+        }
+
+        const apiVersion = ConfigurationService.getDynamicsAPIVersion();
+        for (let i = 0; i < webResources.length; i += batchSize) {
+            const batchWebResources = webResources.slice(i, i + batchSize);
+            const batchBoundary = this.createBoundary("batch");
+            const crlf = "\r\n";
+            const requestParts: string[] = [];
+
+            for (const webResource of batchWebResources) {
+                requestParts.push(
+                    `--${batchBoundary}`,
+                    "Content-Type: application/http",
+                    "Content-Transfer-Encoding: binary",
+                    "",
+                    `GET ${API_DATA_V}${apiVersion}/${ENTITY_WEBRESOURCE_SET}(${webResource.webResourceId})?$select=content,modifiedon&$expand=modifiedby($select=fullname) HTTP/1.1`,
+                    "Accept: application/json",
+                    "",
+                );
+            }
+
+            const batchBody = [
+                ...requestParts,
+                `--${batchBoundary}--`,
+                "",
+            ].join(crlf);
+
+            const responseText = await this.makeRawApiRequest(
+                connection,
+                "POST",
+                `${API_DATA_V}${apiVersion}/$batch`,
+                batchBody,
+                `multipart/mixed; boundary="${batchBoundary}"`
+            );
+
+            const responsePayloads = this.parseBatchJsonResponses(responseText, batchWebResources.length);
+            responsePayloads.forEach((payload, index) => {
+                const webResource = batchWebResources[index];
+                const webResourceDetails = payload as Partial<WebResourceContent>;
+                if (typeof webResourceDetails.content !== "string") {
+                    throw new Error(`Web resource content for '${webResource.webResourceName}' not found or in unexpected format.`);
+                }
+                details.set(webResource.webResourceId, {
+                    ...(webResourceDetails as WebResourceContent),
+                    webResourceId: webResource.webResourceId,
+                });
+            });
+        }
+
+        return details;
+    }
+
+    /**
      * Publishes multiple web resources using one PublishXml request.
      */
     static async publishWebResources(
@@ -588,6 +655,37 @@ export class CrmWebAPI {
 
         validateResponseText?.(responseText);
         return responseText;
+    }
+
+    private static parseBatchJsonResponses(responseText: string, expectedCount: number): unknown[] {
+        const responseSections = responseText.split(/--batchresponse_[^\r\n]+/g);
+        const payloads: unknown[] = [];
+
+        for (const section of responseSections) {
+            const statusMatch = section.match(/HTTP\/1\.1\s+(\d{3})/);
+            if (!statusMatch) {
+                continue;
+            }
+
+            const status = Number(statusMatch[1]);
+            if (status < 200 || status >= 300) {
+                throw new Error(`Batch retrieval returned inner HTTP status ${status}: ${section}`);
+            }
+
+            const jsonStart = section.indexOf("{");
+            const jsonEnd = section.lastIndexOf("}");
+            if (jsonStart === -1 || jsonEnd === -1 || jsonEnd < jsonStart) {
+                throw new Error(`Batch retrieval response did not include a JSON payload: ${section}`);
+            }
+
+            payloads.push(JSON.parse(section.slice(jsonStart, jsonEnd + 1)));
+        }
+
+        if (payloads.length !== expectedCount) {
+            throw new Error(`Batch retrieval returned ${payloads.length} responses for ${expectedCount} requests: ${responseText}`);
+        }
+
+        return payloads;
     }
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { ConnectionExplorer, Connection } from "./views/connectionExplorer";
-import { SolutionExplorer } from "./views/solutionExplorer";
+import { SolutionExplorer, Solution } from "./views/solutionExplorer";
 import { WebResourceExplorer } from "./views/webResourceExplorer";
 import { ConnectionStatusController } from "./connectionStatusController";
 import { registerCommands } from "./commandHandlers";
@@ -16,6 +16,7 @@ import * as crypto from 'crypto';
  */
 let statusBar: vscode.StatusBarItem; 
 let fileStatusBar: vscode.StatusBarItem;
+let solutionStatusBar: vscode.StatusBarItem;
 // Map to track file sync and publish state: { [filePath: string]: { guid: string, published: boolean, hash?: string } }
 const fileSyncState: Map<string, { guid: string, published: boolean, hash?: string }> = new Map();
 
@@ -72,6 +73,24 @@ function initializeFileStatusBar(): void {
     fileStatusBar.text = "File: Not Synced";
     fileStatusBar.tooltip = "Shows Dynamics sync and publish status for the current file.";
     fileStatusBar.show();
+}
+
+function initializeSolutionStatusBar(): void {
+    solutionStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 98);
+    solutionStatusBar.text = "Solution: None";
+    solutionStatusBar.tooltip = "Selected Dynamics solution for publishing web resources.";
+    solutionStatusBar.show();
+}
+
+function updateSolutionStatusBar(solution?: Solution): void {
+    if (solution) {
+        solutionStatusBar.text = `Solution: ${solution.getFriendlyName()}`;
+        solutionStatusBar.tooltip = `Selected Dynamics solution: ${solution.getFriendlyName()} (${solution.solutionUniqueName})`;
+    } else {
+        solutionStatusBar.text = "Solution: None";
+        solutionStatusBar.tooltip = "Select a Dynamics solution before publishing files that are not already linked.";
+    }
+    solutionStatusBar.show();
 }
 
 function updateFileStatusBar(editor?: vscode.TextEditor) {
@@ -168,10 +187,13 @@ function registerTreeDataProviders(
         connectionExplorer
     );
     // Register the SolutionExplorer for the 'vscode-solution-explorer' view.
-    const solutionTreeView = vscode.window.registerTreeDataProvider(
+    const solutionTreeView = vscode.window.createTreeView(
         "vscode-solution-explorer", // Matches the view ID in package.json
-        solutionExplorer
+        { treeDataProvider: solutionExplorer }
     );
+    const solutionSelectionListener = solutionTreeView.onDidChangeSelection(event => {
+        solutionExplorer.setSelectedSolution(event.selection[0]);
+    });
     // Register the WebResourceExplorer for the 'vscode-webresource-explorer' view.
     const webResourceTreeView = vscode.window.registerTreeDataProvider(
         "vscode-webresource-explorer", // Matches the view ID in package.json
@@ -180,7 +202,7 @@ function registerTreeDataProviders(
 
     // Add the tree view registrations to the extension's subscriptions
     // to ensure they are disposed of when the extension is deactivated.
-    context.subscriptions.push(connectionTreeView, solutionTreeView, webResourceTreeView);
+    context.subscriptions.push(connectionTreeView, solutionTreeView, solutionSelectionListener, webResourceTreeView);
 }
 
 /**
@@ -310,12 +332,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         // Setup UI elements like the status bar.
         initializeStatusBar();
         initializeFileStatusBar();
+        initializeSolutionStatusBar();
 
         // Initialize core components:
         const connectionExplorer = new ConnectionExplorer(context);
         const solutionExplorer = new SolutionExplorer(context, []);
         const webResourceExplorer = new WebResourceExplorer([]);
         const connectionStatusController = new ConnectionStatusController(statusBar);
+        const selectedSolutionListener = solutionExplorer.onDidChangeSelectedSolution(updateSolutionStatusBar);
         
         registerTreeDataProviders(context, connectionExplorer, solutionExplorer, webResourceExplorer);
 
@@ -329,7 +353,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         
         registerFileStatusListeners(context);
 
-        context.subscriptions.push(statusBar, fileStatusBar);
+        context.subscriptions.push(statusBar, fileStatusBar, solutionStatusBar, selectedSolutionListener);
 
         // No general "extension active" message as per previous user request
 
@@ -354,6 +378,9 @@ export async function deactivate(): Promise<void> {
     }
     if (fileStatusBar) {
         fileStatusBar.dispose();
+    }
+    if (solutionStatusBar) {
+        solutionStatusBar.dispose();
     }
     // Remove all persistent MSAL token caches for all connections
     try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -303,6 +303,7 @@ async function showSettingsForm(
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     try {
         await vscode.commands.executeCommand("setContext", "wrm.viewsReady", false);
+        await vscode.commands.executeCommand("setContext", "wrm.solutionLinked", false);
 
         // Register providers first so the activity bar icon and tree views appear as soon as the extension is ready.
         initializeStatusBar();
@@ -313,7 +314,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         const solutionExplorer = new SolutionExplorer(context, []);
         const webResourceExplorer = new WebResourceExplorer([]);
         const connectionStatusController = new ConnectionStatusController(statusBar);
-        const selectedSolutionListener = solutionExplorer.onDidChangeSelectedSolution(updateSolutionStatusBar);
+        const selectedSolutionListener = solutionExplorer.onDidChangeSelectedSolution(solution => {
+            updateSolutionStatusBar(solution);
+            void vscode.commands.executeCommand("setContext", "wrm.solutionLinked", !!solution);
+        });
 
         registerTreeDataProviders(context, connectionExplorer, solutionExplorer, webResourceExplorer);
 
@@ -376,6 +380,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     } catch (error: unknown) {
         await vscode.commands.executeCommand("setContext", "wrm.viewsReady", false);
+        await vscode.commands.executeCommand("setContext", "wrm.solutionLinked", false);
         const message = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Error activating Web Resource Manager extension: ${message}`);
         // Log the full error to the console for more detailed debugging.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -286,6 +286,8 @@ async function showSettingsForm(
  */
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     try {
+        await vscode.commands.executeCommand("setContext", "wrm.viewsReady", false);
+
         let initialCheckResult = performInitialChecks();
 
         if (initialCheckResult.status === "CRITICAL_SETTINGS_MISSING") {
@@ -354,10 +356,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         registerFileStatusListeners(context);
 
         context.subscriptions.push(statusBar, fileStatusBar, solutionStatusBar, selectedSolutionListener);
+        await vscode.commands.executeCommand("setContext", "wrm.viewsReady", true);
 
         // No general "extension active" message as per previous user request
 
     } catch (error: unknown) {
+        await vscode.commands.executeCommand("setContext", "wrm.viewsReady", false);
         const message = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Error activating Web Resource Manager extension: ${message}`);
         // Log the full error to the console for more detailed debugging.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,18 @@ let solutionStatusBar: vscode.StatusBarItem;
 // Map to track file sync and publish state: { [filePath: string]: { guid: string, published: boolean, hash?: string } }
 const fileSyncState: Map<string, { guid: string, published: boolean, hash?: string }> = new Map();
 
+class LoadingTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+    private readonly loadingItem = new vscode.TreeItem("Loading Web Resource Manager...", vscode.TreeItemCollapsibleState.None);
+
+    getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(): vscode.ProviderResult<vscode.TreeItem[]> {
+        return [this.loadingItem];
+    }
+}
+
 /**
  * Performs initial configuration and workspace checks essential for the extension's operation.
  * This includes verifying required settings (Client ID, API Version, Config Folder) and ensuring a workspace is open.
@@ -181,6 +193,10 @@ function registerTreeDataProviders(
     solutionExplorer: SolutionExplorer,
     webResourceExplorer: WebResourceExplorer
 ): void {
+    const loadingTreeView = vscode.window.registerTreeDataProvider(
+        "vscode-webrm-loading",
+        new LoadingTreeDataProvider()
+    );
     // Register the ConnectionExplorer for the 'vscode-connection-explorer' view.
     const connectionTreeView = vscode.window.registerTreeDataProvider(
         "vscode-connection-explorer", // Matches the view ID in package.json
@@ -202,7 +218,7 @@ function registerTreeDataProviders(
 
     // Add the tree view registrations to the extension's subscriptions
     // to ensure they are disposed of when the extension is deactivated.
-    context.subscriptions.push(connectionTreeView, solutionTreeView, solutionSelectionListener, webResourceTreeView);
+    context.subscriptions.push(loadingTreeView, connectionTreeView, solutionTreeView, solutionSelectionListener, webResourceTreeView);
 }
 
 /**
@@ -288,6 +304,32 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     try {
         await vscode.commands.executeCommand("setContext", "wrm.viewsReady", false);
 
+        // Register providers first so the activity bar icon and tree views appear as soon as the extension is ready.
+        initializeStatusBar();
+        initializeFileStatusBar();
+        initializeSolutionStatusBar();
+
+        const connectionExplorer = new ConnectionExplorer(context);
+        const solutionExplorer = new SolutionExplorer(context, []);
+        const webResourceExplorer = new WebResourceExplorer([]);
+        const connectionStatusController = new ConnectionStatusController(statusBar);
+        const selectedSolutionListener = solutionExplorer.onDidChangeSelectedSolution(updateSolutionStatusBar);
+
+        registerTreeDataProviders(context, connectionExplorer, solutionExplorer, webResourceExplorer);
+
+        registerCommands(
+            context,
+            connectionExplorer,
+            solutionExplorer,
+            webResourceExplorer,
+            connectionStatusController
+        );
+
+        registerFileStatusListeners(context);
+
+        context.subscriptions.push(statusBar, fileStatusBar, solutionStatusBar, selectedSolutionListener);
+        await vscode.commands.executeCommand("setContext", "wrm.viewsReady", true);
+
         let initialCheckResult = performInitialChecks();
 
         if (initialCheckResult.status === "CRITICAL_SETTINGS_MISSING") {
@@ -315,48 +357,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 if (initialCheckResult.status !== "ALL_CHECKS_PASSED") {
                     if (initialCheckResult.status === "CRITICAL_SETTINGS_MISSING") {
                         const stillMissing = initialCheckResult.missing.join(', ');
-                        vscode.window.showErrorMessage(`Critical settings are still missing after configuration: ${stillMissing}. Extension will not activate.`);
+                        vscode.window.showErrorMessage(`Critical settings are still missing after configuration: ${stillMissing}. Configure them before connecting.`);
                     }
                     // WORKSPACE_MISSING message is handled by performInitialChecks
-                    return; // Halt activation
+                    return;
                 }
                 // If checks now pass, fall through to normal activation
             } else { // CANCELLED
-                vscode.window.showInformationMessage("Settings configuration was cancelled. Extension will not activate.");
-                return; // Halt activation
+                vscode.window.showInformationMessage("Settings configuration was cancelled. Configure settings before connecting.");
+                return;
             }
         } else if (initialCheckResult.status === "WORKSPACE_MISSING") {
             // Error message already shown by performInitialChecks
-            return; // Halt activation
+            return;
         }
-        // If initialCheckResult.status is "ALL_CHECKS_PASSED", proceed with normal activation.
-
-        // Setup UI elements like the status bar.
-        initializeStatusBar();
-        initializeFileStatusBar();
-        initializeSolutionStatusBar();
-
-        // Initialize core components:
-        const connectionExplorer = new ConnectionExplorer(context);
-        const solutionExplorer = new SolutionExplorer(context, []);
-        const webResourceExplorer = new WebResourceExplorer([]);
-        const connectionStatusController = new ConnectionStatusController(statusBar);
-        const selectedSolutionListener = solutionExplorer.onDidChangeSelectedSolution(updateSolutionStatusBar);
-        
-        registerTreeDataProviders(context, connectionExplorer, solutionExplorer, webResourceExplorer);
-
-        registerCommands(
-            context,
-            connectionExplorer,
-            solutionExplorer,
-            webResourceExplorer,
-            connectionStatusController
-        );
-        
-        registerFileStatusListeners(context);
-
-        context.subscriptions.push(statusBar, fileStatusBar, solutionStatusBar, selectedSolutionListener);
-        await vscode.commands.executeCommand("setContext", "wrm.viewsReady", true);
 
         // No general "extension active" message as per previous user request
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -304,6 +304,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     try {
         await vscode.commands.executeCommand("setContext", "wrm.viewsReady", false);
         await vscode.commands.executeCommand("setContext", "wrm.solutionLinked", false);
+        await vscode.commands.executeCommand("setContext", "wrm.connected", false);
 
         // Register providers first so the activity bar icon and tree views appear as soon as the extension is ready.
         initializeStatusBar();
@@ -381,6 +382,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     } catch (error: unknown) {
         await vscode.commands.executeCommand("setContext", "wrm.viewsReady", false);
         await vscode.commands.executeCommand("setContext", "wrm.solutionLinked", false);
+        await vscode.commands.executeCommand("setContext", "wrm.connected", false);
         const message = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Error activating Web Resource Manager extension: ${message}`);
         // Log the full error to the console for more detailed debugging.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ function initializeFileStatusBar(): void {
 }
 
 function initializeSolutionStatusBar(): void {
-    solutionStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 98);
+    solutionStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 99.5);
     solutionStatusBar.text = "Solution: None";
     solutionStatusBar.tooltip = "Selected Dynamics solution for publishing web resources.";
     solutionStatusBar.show();

--- a/src/views/connectionExplorer.ts
+++ b/src/views/connectionExplorer.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 // Keytar and Express imports were commented out as unused. If needed, they should be uncommented.
-import { v1 as uuidv1 } from "uuid";
+import { randomUUID } from "crypto";
 import { AuthProvider } from "../auth/authProvider";
 import { ConfigurationService } from "./../configurationService"; 
 import * as fs from "fs";
@@ -210,7 +210,7 @@ export class Connection extends vscode.TreeItem {
             typeof connectionObj.connectionId === "undefined" ||
             connectionObj.connectionId === ""
         ) {
-            this.connectionId = uuidv1().replace(/-/g, ""); // Generate a UUID and remove hyphens.
+            this.connectionId = randomUUID().replace(/-/g, ""); // Generate a UUID and remove hyphens.
         } else {
             this.connectionId = connectionObj.connectionId;
         }

--- a/src/views/solutionExplorer.ts
+++ b/src/views/solutionExplorer.ts
@@ -16,8 +16,11 @@ interface RawSolution {
  */
 export class SolutionExplorer implements vscode.TreeDataProvider<Solution> {
     private solutions: Solution[] = [];
+    private selectedSolution?: Solution;
     private _onDidChangeTreeData: vscode.EventEmitter<Solution | undefined | null | void> = new vscode.EventEmitter<Solution | undefined | null | void>();
+    private _onDidChangeSelectedSolution: vscode.EventEmitter<Solution | undefined> = new vscode.EventEmitter<Solution | undefined>();
     readonly onDidChangeTreeData: vscode.Event<Solution | undefined | null | void> = this._onDidChangeTreeData.event;
+    readonly onDidChangeSelectedSolution: vscode.Event<Solution | undefined> = this._onDidChangeSelectedSolution.event;
 
     /**
      * Creates an instance of SolutionExplorer.
@@ -82,6 +85,7 @@ export class SolutionExplorer implements vscode.TreeDataProvider<Solution> {
                 this // Pass reference to SolutionExplorer for callbacks
             )
         );
+        this.clearSelectedSolutionIfMissing();
         this.refresh();
     }
     
@@ -92,7 +96,26 @@ export class SolutionExplorer implements vscode.TreeDataProvider<Solution> {
      */
     public setSolutions(solutions: Solution[]): void {
         this.solutions = solutions;
+        this.clearSelectedSolutionIfMissing();
         this.refresh();
+    }
+
+    /**
+     * Tracks the solution currently selected in the Solutions tree.
+     */
+    public setSelectedSolution(solution: Solution | undefined): void {
+        if (this.selectedSolution?.solutionId === solution?.solutionId) {
+            return;
+        }
+        this.selectedSolution = solution;
+        this._onDidChangeSelectedSolution.fire(solution);
+    }
+
+    /**
+     * Returns the solution currently selected in the Solutions tree, if any.
+     */
+    public getSelectedSolution(): Solution | undefined {
+        return this.selectedSolution;
     }
 
 
@@ -132,6 +155,7 @@ export class SolutionExplorer implements vscode.TreeDataProvider<Solution> {
      */
     clearSolutions(): void {
         this.solutions = [];
+        this.setSelectedSolution(undefined);
         this.refresh();
     }
 
@@ -140,6 +164,16 @@ export class SolutionExplorer implements vscode.TreeDataProvider<Solution> {
      */
     refresh(): void {
         this._onDidChangeTreeData.fire();
+    }
+
+    private clearSelectedSolutionIfMissing(): void {
+        if (!this.selectedSolution) {
+            return;
+        }
+        const selectedStillExists = this.solutions.some(solution => solution.solutionId === this.selectedSolution?.solutionId);
+        if (!selectedStillExists) {
+            this.setSelectedSolution(undefined);
+        }
     }
 }
 


### PR DESCRIPTION
### 1.1.9
- Updated MSAL to `@azure/msal-node` 5.1.5 and raised the VS Code engine/runtime target for Node 20 support.
- Removed the `uuid` dependency and now use Node's built-in UUID generation.
- Added selected-solution tracking and a status bar indicator for the solution used when publishing.
- Publishing no longer requires opening a web resource from the extension first. The active file is matched to a server web resource by workspace-relative path.
- If the active file is not in the selected solution, the extension prompts to add it before publishing.
- If the active file does not exist on the server, the extension prompts to create it, add it to the selected solution, and publish it.
- Removed `webRM.pullLatestVersionFromServer`. Opening a web resource from the extension now always pulls the server version, while still warning when an existing local file differs from a server version modified by another user.
- Cleaned up duplicate Cancel buttons in publish confirmation dialogs.
- Added linked-solution actions in the Web Resources toolbar for pushing local files to the server or replacing local files with server versions.
- Bulk push only updates web resources in the linked solution, confirms the number of changed resources, batches content updates in groups, and publishes all changed web resources in one publish request.
- Bulk replace only updates local files for web resources in the linked solution and confirms the number of local files that will be replaced.